### PR TITLE
fix(ci): remove dependency on lint-react job in PHP linting workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,6 @@ jobs:
 
   lint-php:
     runs-on: ubuntu-latest
-    needs: lint-react
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
This pull request includes a minor change to the CI workflow configuration. The dependency on the `lint-react` job for the `lint-php` job has been removed.